### PR TITLE
stop auto-importing n8n stuff on every stack start

### DIFF
--- a/.local/commands/n8n-im.sh
+++ b/.local/commands/n8n-im.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## [help]
+## Import tracked N8N credentials and workflows.
+## [/help]
+
+set -e
+
+run_n8n_command import

--- a/.local/n8n/cli.js
+++ b/.local/n8n/cli.js
@@ -456,7 +456,11 @@ async function templateCredentialsFiles(filePaths) {
 }
 
 const commands = {
-  async configure(ownerApiKey) {
+  configure() {
+    // Exists only to ensure the owner account is configured (done
+    // by the logic that runs before any command).
+  },
+  async import(ownerApiKey) {
     await importN8nFiles('credentials', templateCredentialsFiles)
     await importWorkflows(ownerApiKey)
   },


### PR DESCRIPTION
auto-importing on the stack start may (and will!) erase the progress you've made in n8n with your workflows in these cases:
- computer restart? forget about it. stack halts or you stop it beforehand. on next start the changes from code are auto-applied trashing your work
- for some reason you run `up` or `upenv` on top of already running stack

here we make it explicit. want an import? run the corresponding command