### PR TITLE
Update Traefik image to latest version

### DIFF
--- a/.local/docker-compose.yml
+++ b/.local/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   traefik:
     container_name: "$COMPOSE_PROJECT_NAME--traefik"
-    image: traefik
+    image: traefik:latest
     restart: always
     command:
       - "--providers.docker=true"


### PR DESCRIPTION
Fix Traefik Docker API 400 Error with latest MacOS Docker Desktop

## Problem
Traefik container was throwing continuous errors:
```
ERR Failed to retrieve information of the docker client and server host 
error="Error response from daemon: API returned a 400 (Bad Request)"
```

## Root Cause
- Using "traefik" stable version caused API version incompatibility with Docker daemon
- Ambiguous API negotiation between Traefik and Docker